### PR TITLE
Fix GHSA-3hpf-ff72-j67p

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1211,13 +1211,13 @@ packages:
     source: hosted
     version: "2.3.3"
   shared_preferences_android:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: shared_preferences_android
-      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
+      sha256: "7f172d1b06de5da47b6264c2692ee2ead20bbbc246690427cdb4fc301cd0c549"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.4"
   shared_preferences_foundation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,16 +56,19 @@ dependencies:
   flutter_launcher_icons: ^0.14.1
   flutter_native_splash: ^2.4.3
   showcaseview: ^3.0.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
   flutter_lints: ^5.0.0
   build_runner: ^2.4.13
   custom_lint: ^0.7.0
   riverpod_lint: ^2.6.3
   json_serializable: ^6.9.0
   msix: ^3.16.8
+
+dependency_overrides:
+  shared_preferences_android: ^2.3.4
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Fixes GHSA-3hpf-ff72-j67p by enforcing transitive Dart dependency `shared_preferences_android` (from `supabase_flutter`) to `^2.3.4`.